### PR TITLE
Replace arma-actions/hemtt with direct download script

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -93,9 +93,10 @@ jobs:
     
     - name: Install HEMTT
       run: |
-        curl -fsSL https://github.com/BrettMayson/HEMTT/releases/latest/download/linux-x64.zip -o hemtt.zip
-        unzip -q hemtt.zip
-        echo "$PWD/hemtt" >> "$GITHUB_PATH"
+        curl -fsSL https://github.com/BrettMayson/HEMTT/releases/latest/download/linux-x64.zip -o "$RUNNER_TEMP/hemtt.zip"
+        unzip -q "$RUNNER_TEMP/hemtt.zip" -d "$RUNNER_TEMP/hemtt"
+        chmod +x "$RUNNER_TEMP/hemtt/hemtt"
+        echo "$RUNNER_TEMP/hemtt" >> "$GITHUB_PATH"
 
     - name: Run HEMTT build
       run: hemtt release

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -92,7 +92,10 @@ jobs:
         path: .
     
     - name: Install HEMTT
-      uses: arma-actions/hemtt@c9b053ccf9755334a612618700e2efe79fd9c59c # main
+      run: |
+        curl -fsSL https://github.com/BrettMayson/HEMTT/releases/latest/download/linux-x64.zip -o hemtt.zip
+        unzip -q hemtt.zip
+        echo "$PWD/hemtt" >> "$GITHUB_PATH"
 
     - name: Run HEMTT build
       run: hemtt release


### PR DESCRIPTION
Replaces the `arma-actions/hemtt` third-party action with a `run` step that downloads the latest HEMTT release directly from GitHub and adds it to `$PATH`.

## Changes
- Downloads `linux-x64.zip` from `BrettMayson/HEMTT` latest release via `curl`
- Extracts with `unzip` and appends the binary directory to `$GITHUB_PATH`
- Removes the pinned third-party action dependency

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kee95d76YbvhpF7pS6xzYh)_